### PR TITLE
Return a raw transactionStatus when pollTransation

### DIFF
--- a/src/Pesepay.php
+++ b/src/Pesepay.php
@@ -54,8 +54,9 @@ class Pesepay
         $referenceNumber = $jsonDecoded['referenceNumber'];
         $pollUrl = $jsonDecoded['pollUrl'];
         $paid = $jsonDecoded['transactionStatus'] == 'SUCCESS';
+        $transactionStatus = $jsonDecoded['transactionStatus'];
 
-        return new Response($referenceNumber, $pollUrl, null, $paid);
+        return new Response($referenceNumber, $pollUrl, null, $paid, $transactionStatus);
     }
 
     public function checkPayment($referenceNumber) {

--- a/src/Response.php
+++ b/src/Response.php
@@ -8,13 +8,15 @@ class Response {
     private $pollUrl;
     private $redirectUrl;
     private $paid;
+    private $transactionStatus;
 
-    public function __construct($referenceNumber, $pollUrl, $redirectUrl = null, $paid = false) {
+    public function __construct($referenceNumber, $pollUrl, $redirectUrl = null, $paid = false, $transactionStatus = null) {
         $this->success = true;
         $this->referenceNumber = $referenceNumber;
         $this->pollUrl = $pollUrl;
         $this->redirectUrl = $redirectUrl;
         $this->paid = $paid;
+        $this->transactionStatus = $transactionStatus;
     }
 
     public function success() {
@@ -35,6 +37,10 @@ class Response {
 
     public function paid() {
         return $this->paid;
+    }
+
+    public function transactionStatus() {
+        return $this->transactionStatus;
     }
 }
 


### PR DESCRIPTION
Return the raw transaction status when the pollTransaction() method is called, and also added the transactionStatus() method to the Response class.

The $transactionStatus will return the raw/actual status, e.g., 'SUCCESS', 'CLOSED_PERIOD_ELAPSED', 'PENDING', etc., allowing developers to have more control and insight into the actual transaction status.